### PR TITLE
Exclude pyparsing from coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
         # Skip coverage on pypy so the build doesn't take 15 minutes.
         $(type -p trial) --testmodule=imaginary/__init__.py
     else
-        coverage run --branch --source=imaginary $(type -p trial) --testmodule=imaginary/__init__.py
+        coverage run --branch --source=imaginary --omit=imaginary/pyparsing.py $(type -p trial) --testmodule=imaginary/__init__.py
     fi
   - |
     coverage report -m


### PR DESCRIPTION
It's a third-party module that we include verbatim and we don't actually test it. No reason for that to drag down our coverage numbers.
