### PR TITLE
move 'wear' action to 'garments' module

### DIFF
--- a/imaginary/action.py
+++ b/imaginary/action.py
@@ -609,42 +609,6 @@ class Remove(TargetAction):
 
 
 
-class Wear(TargetAction):
-    expr = (pyparsing.Literal("wear") +
-            pyparsing.White() +
-            targetString("target"))
-
-    targetInterface = iimaginary.IClothing
-    actorInterface = iimaginary.IClothingWearer
-
-    def do(self, player, line, target):
-        from imaginary import garments
-        try:
-            player.putOn(target)
-        except garments.TooBulky, e:
-            raise eimaginary.ActionFailure(events.ThatDoesntWork(
-                actor=player.thing,
-                target=target.thing,
-                actorMessage=language.Sentence([
-                    language.Noun(e.wornGarment.thing).definiteNounPhrase(),
-                    u" you are already wearing is too bulky for you to do"
-                    u" that."]),
-                otherMessage=language.Sentence([
-                    player.thing,
-                    u" wrestles with basic personal problems."])))
-
-        evt = events.Success(
-            actor=player.thing,
-            target=target.thing,
-            actorMessage=(u"You put on ",
-                          language.Noun(target.thing).definiteNounPhrase(),
-                          "."),
-            otherMessage=language.Sentence([
-                player.thing, " puts on ", target.thing, "."]))
-        evt.broadcast()
-
-
-
 class Equipment(Action):
     expr = pyparsing.Literal("equipment")
 

--- a/imaginary/garments.py
+++ b/imaginary/garments.py
@@ -84,6 +84,10 @@ for gslot in GARMENT_SLOTS:
 
 
 class Wear(TargetAction):
+    """
+    The 'wear' action, whereby a player can wear a garment, filling any
+    clothing slots that the garment is responsible for.
+    """
     expr = (pyparsing.Literal("wear") +
             pyparsing.White() +
             targetString("target"))

--- a/imaginary/garments.py
+++ b/imaginary/garments.py
@@ -111,15 +111,14 @@ class Wear(TargetAction):
                     player.thing,
                     u" wrestles with basic personal problems."])))
 
-        evt = events.Success(
+        events.Success(
             actor=player.thing,
             target=target.thing,
             actorMessage=(u"You put on ",
                           language.Noun(target.thing).definiteNounPhrase(),
                           "."),
             otherMessage=language.Sentence([
-                player.thing, " puts on ", target.thing, "."]))
-        evt.broadcast()
+                player.thing, " puts on ", target.thing, "."])).broadcast()
 
 
 


### PR DESCRIPTION
In support of #55 and #54, start to split out an action from the too-long `action` module.