### PR TITLE
re-wrap some docstrings that are mis-formatted or too long

### DIFF
--- a/imaginary/eimaginary.py
+++ b/imaginary/eimaginary.py
@@ -22,23 +22,24 @@ class NoSuchCommand(ImaginaryError):
 
 class AmbiguousArgument(ImaginaryError):
     """
-    One or more of the inputs specified can not be narrowed down to
-    just one thing.  This can be due to the presence of multiple
-    things with similar names, or due to the absence of anything named
-    similarly to the given input.
+    One or more of the inputs specified can not be narrowed down to just one
+    thing.  This can be due to the presence of multiple things with similar
+    names, or due to the absence of anything named similarly to the given
+    input.
 
     @ivar action: The action which was being processed when an ambiguity was
-    found.
+        found.
 
+    @ivar part: The part of the command which was ambiguous.  Typically
+        something like 'target' or 'tool'.
     @type part: C{str}
-    @ivar part: The part of the command which was ambiguous.
-    Typically something like 'target' or 'tool'.
 
+    @ivar partValue: The string which was supplied by the user for the
+        indicated part.
     @type partValue: C{str}
-    @ivar partValue: The string which was supplied by the user for the indicated part.
 
-    @type objects: C{list} of C{IThing}
     @ivar objects: The objects which were involved in the ambiguity.
+    @type objects: C{list} of C{IThing}
     """
 
     def __init__(self, action, part, partValue, objects):

--- a/imaginary/objects.py
+++ b/imaginary/objects.py
@@ -89,7 +89,8 @@ class Thing(item.Item):
 
     A L{Thing} is also the object which serves as the persistent nexus of
     powerups that define behavior.  An L{_Enhancement} is a powerup for a
-    L{Thing}.  L{Thing}s can be powered up for a number of different interfaces:
+    L{Thing}.  L{Thing}s can be powered up for a number of different
+    interfaces:
 
         - L{iimaginary.IMovementRestriction}, for preventing the L{Thing} from
           moving around,
@@ -100,9 +101,9 @@ class Thing(item.Item):
         - L{iimaginary.ILinkAnnotator}, which can provide annotations on links
           incoming to or outgoing from the L{Thing}'s L{Idea},
 
-        - L{iimaginary.ILocationLinkAnnotator}, which can provide annotations on
-          links to or from any L{Thing}'s L{Idea} which is ultimately located
-          within the powered-up L{Thing}.
+        - L{iimaginary.ILocationLinkAnnotator}, which can provide annotations
+          on links to or from any L{Thing}'s L{Idea} which is ultimately
+          located within the powered-up L{Thing}.
 
         - L{iimaginary.IDescriptionContributor}, which provide components of
           the L{Thing}'s description when viewed with the L{Look} action.

--- a/imaginary/test/test_text.py
+++ b/imaginary/test/test_text.py
@@ -323,7 +323,7 @@ class AsynchronousIncrementalUTF8DecoderTestCase(unittest.TestCase):
 
 
 
-class UTF8TerminalBuffer(helper.TerminalBuffer):
+class UTF8TerminalBuffer(helper.TerminalBuffer, object):
     # An unfortunate hack'n'paste of
     # helper.TerminalBuffer.insertAtCursor
     def insertAtCursor(self, b):
@@ -341,6 +341,17 @@ class UTF8TerminalBuffer(helper.TerminalBuffer):
             else:
                 self.lines[self.y][self.x] = ch
             self.x += 1
+
+
+    def __str__(self):
+        """
+        Workaround for https://twistedmatrix.com/trac/ticket/8843
+        """
+        supered = super(UTF8TerminalBuffer, self)
+        maybeBytes = getattr(supered, "__bytes__")
+        if maybeBytes:
+            return maybeBytes()
+        return supered.__str__()
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ distobj = setup(
         "Topic :: Terminals"],
     packages=find_packages() + ['axiom.plugins', 'xmantissa.plugins'],
     install_requires=[
-        "twisted>=14.0.0,<16.4.0",
+        "twisted>=14.0.0",
         "epsilon>=0.7.0",
         "characteristic>=0.1.0",
         "axiom>=0.7.1",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ distobj = setup(
         "Topic :: Terminals"],
     packages=find_packages() + ['axiom.plugins', 'xmantissa.plugins'],
     install_requires=[
-        "twisted>=14.0.0",
+        "twisted>=14.0.0,<16.4.0",
         "epsilon>=0.7.0",
         "characteristic>=0.1.0",
         "axiom>=0.7.1",


### PR DESCRIPTION
`eimaginary` and `objects` included.
