### PR TITLE
Deal with an actor missing the required actorInterface

### DIFF
--- a/src/imaginary/action.py
+++ b/src/imaginary/action.py
@@ -106,7 +106,9 @@ class Action(object):
         def thunk():
             begin = time.time()
             try:
-                actor = self.actorInterface(player)
+                actor = self.actorInterface(player, None)
+                if actor is None:
+                    return self.incapableActor(player, line, match)
                 for (k, v) in match.items():
                     try:
                         objs = self.resolve(player, k, v)
@@ -126,6 +128,16 @@ class Action(object):
                         stat_actionDuration=end - begin,
                         stat_actionExecuted=1)
         events.runEventTransaction(player.store, thunk)
+
+
+    def incapableActor(self, player, line, match):
+        """
+        This hook is invoked when an actor does not provide the required
+        interface.
+        """
+        raise eimaginary.ActionFailure(events.IncapableActor(
+            actor=player,
+        ))
 
 
     def cantFind(self, player, actor, slot, name):

--- a/src/imaginary/events.py
+++ b/src/imaginary/events.py
@@ -177,6 +177,20 @@ def runEventTransaction(store, func, *args, **kwargs):
 
 
 
+class IncapableActor(Event):
+    """
+    An action was attempted by a thing which lacks some part of the
+    implementation required to perform that action.
+    """
+    def __init__(
+            self,
+            actorMessage="Your train of thought slips away.",
+            **kw
+    ):
+        super(IncapableActor, self).__init__(actorMessage=actorMessage, **kw)
+
+
+
 class ThatDoesntMakeSense(Event):
     """
     An action was attempted which is logically impossible.

--- a/src/imaginary/iimaginary.py
+++ b/src/imaginary/iimaginary.py
@@ -205,6 +205,9 @@ class IMovementRestriction(Interface):
 
 
 class IActor(Interface):
+    """
+    A motivated agent in the world.
+    """
     hitpoints = Attribute("L{Points} instance representing hit points")
     experience = Attribute("C{int} representing experience")
     level = Attribute("C{int} representing player's level")
@@ -783,4 +786,3 @@ class IElectromagneticMedium(Interface):
             Alice via L{IElectromagneticMedium} - he can "see" her via
             L{ISoundMedium} or whatever.
         """
-

--- a/src/imaginary/test/test_actions.py
+++ b/src/imaginary/test/test_actions.py
@@ -3,10 +3,14 @@
 Unit tests for Imaginary actions.
 """
 
+from zope.interface import (
+    Interface,
+)
+
 from twisted.trial import unittest
 from twisted.python import filepath
 
-from imaginary import iimaginary, objects, events
+from imaginary import iimaginary, objects, events, pyparsing
 from imaginary.action import Action, TargetAction, Help
 from imaginary.test import commandutils
 from imaginary.test.commandutils import E
@@ -68,12 +72,42 @@ class TargetActionTests(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
 
+class IUnimplemented(Interface):
+    """
+    This is an interface that nothing implements.
+    """
+
+
+
+class Unperformable(Action):
+    """
+    This is an action that no one can perform.
+    """
+    actorInterface = IUnimplemented
+
+    expr = pyparsing.Literal("unperformable")
+
+
 class Actions(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
     def testBadCommand(self):
         self._test(
             "jibber jabber",
             ["Bad command or filename"])
+
+
+    def test_missingActorInterface(self):
+        """
+        If the player attempts to invoke an action for which the player does not
+        provide the required C{actorInterface} then the action is not invoked
+        and a reasonable explanation is given to the player.
+        """
+        self._test(
+            "unperformable",
+            ["Your train of thought slips away."],
+            [],
+        )
+
 
     def testInventory(self):
         # There ain't no stuff

--- a/src/imaginary/wiring/player.py
+++ b/src/imaginary/wiring/player.py
@@ -8,7 +8,9 @@ from twisted.python import log
 from imaginary import iimaginary, eimaginary, text as T
 
 from imaginary.text import flatten
-from imaginary.action import Action
+from imaginary.action import (
+    runAction,
+)
 
 
 @implementer(iimaginary.IEventObserver)
@@ -64,7 +66,7 @@ class Player(object):
             self.proto.write('\r\nerror\r\n')
 
         self.send(('> ', line, '\n'))
-        d = defer.maybeDeferred(Action.parse, self.actor, line)
+        d = defer.maybeDeferred(runAction, self.actor, line)
         d.addCallbacks(cbParse, ebParse)
         d.addErrback(ebAmbiguity)
         d.addErrback(ebUnexpected)


### PR DESCRIPTION
Fixes #100 

Just a draft for now.  663b154 passes the test suite but I'm not sure this is all the right direction to go.  I don't like the manual calls to `.reify()()`.  I wonder if there is a cleaner solution that involves re-working the transaction/event interface instead.