### PR TITLE
Make the protagonist in example_game a manipulator

### DIFF
--- a/doc/examples/example_world.py
+++ b/doc/examples/example_world.py
@@ -5,6 +5,9 @@ from imaginary.world import ImaginaryWorld
 from imaginary.objects import Thing, Container, Exit
 from imaginary.garments import createShirt, createPants
 from imaginary.iimaginary import IClothing, IClothingWearer
+from imaginary.manipulation import (
+    Manipulator,
+)
 
 from examplegame.squeaky import Squeaker
 
@@ -23,6 +26,10 @@ def world(store):
     origin = room("The Beginning", "Everything here looks fresh and new.")
     world = ImaginaryWorld(store=store, origin=origin)
     protagonist = world.create("An Example Player")
+    # Allow the protagonist to use the mildly privileged "manipulator"
+    # actions.
+    Manipulator.createFor(protagonist)
+
     shirt = createShirt(store=store, name="shirt", location=world.origin)
     pants = createPants(store=store, name="pants", location=world.origin)
     middle = room(


### PR DESCRIPTION
Fixes #101 

I could have just imported the module to get the `NonManipulator` adapter registered.  I figured it would be more fun to grant access to the illuminate command than to show a funny message about it not being available though.

At some point we should do some plugin-y things so you can be confident the intended adapters have been registered though, regardless of which modules _happen_ to be imported by some loaded application code.
