### PR TITLE
Fix vending machine description generation

### DIFF
--- a/ExampleGame/examplegame/quiche.py
+++ b/ExampleGame/examplegame/quiche.py
@@ -103,14 +103,6 @@ class VendingMachine(item.Item, objects.Containment, Enhancement):
 
 
 
-def createVendingMachine(store, name, description=u""):
-    o = objects.Thing(store=store, name=name, description=description)
-    VendingMachine.createFor(o)
-    return o
-
-
-
 createCoin = createCreator((Quarter, {}))
 createVendingMachine = createCreator((VendingMachine, {}))
 createQuiche = createCreator()
-

--- a/ExampleGame/examplegame/quiche.py
+++ b/ExampleGame/examplegame/quiche.py
@@ -44,6 +44,15 @@ class Quarter(item.Item, Coinage, Enhancement):
 class VendingMachine(item.Item, objects.Containment, Enhancement):
     implements(iimaginary.IContainer)
 
+    contentsTemplate = attributes.text(
+        doc="""
+        Define how the contents of this container are presented to observers.
+        Certain substrings will be given special treatment.
+
+        @see: L{imaginary.language.ConceptTemplate}
+        """,
+        allowNone=True, default=None)
+
     capacity = attributes.integer(doc="""
     Units of weight which can be contained.
     """, allowNone=False, default=1)

--- a/ExampleGame/examplegame/quiche.py
+++ b/ExampleGame/examplegame/quiche.py
@@ -84,7 +84,6 @@ class VendingMachine(item.Item, objects.Containment, Enhancement):
             except StopIteration:
                 evt = events.Success(
                     actor=self.thing,
-                    target=obj,
                     otherMessage=language.Sentence([self.thing, " thumps loudly."]))
             else:
                 evt = events.Success(

--- a/ExampleGame/examplegame/test/test_quiche.py
+++ b/ExampleGame/examplegame/test/test_quiche.py
@@ -201,6 +201,29 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
                     "Vendy thumps loudly and spits out a quiche onto the ground."])
 
 
+    def testEmptyVendingMachinePurchase(self):
+        """
+        Putting 5 coins into an empty vending machine causes it to clunk but does
+        not cause anything to be spit out.
+        """
+        self._create()
+        self._drop()
+        self._open()
+        for i in range(4):
+            self._create_quarter("quarter")
+            self._put_quarter("quarter")
+
+        self._create_quarter("quarter")
+        self._test(
+            "put quarter in vendy",
+            ["You put quarter in vendy.",
+             "Vendy thumps loudly.",
+            ],
+            ["Test Player puts quarter in vendy.",
+             "Vendy thumps loudly."],
+        )
+
+
     def testProgrammaticQuichePurchase(self):
         location = objects.Thing(store=self.store, name=u"room")
         icloc = objects.Container.createFor(location, capacity=500)

--- a/ExampleGame/examplegame/test/test_quiche.py
+++ b/ExampleGame/examplegame/test/test_quiche.py
@@ -1,3 +1,4 @@
+
 from twisted.trial import unittest
 
 from imaginary import objects, iimaginary
@@ -7,60 +8,166 @@ from examplegame import quiche
 
 
 class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
-    def testTheyExist(self):
-        self._test("create the 'vending machine' named vendy",
+    def _create(self):
+        """
+        Create the vending machine.
+        """
+        self._test("create the 'vending machine' named vendy A vending machine.",
                    ["You create vendy."],
-                   ["Test Player creates vendy."])
+                   ["Test Player creates vendy."],
+        )
+
+
+    def _drop(self):
+        self._test(
+            "drop vendy",
+            ["You drop vendy."],
+            ["Test Player drops vendy."],
+        )
+
+
+    def _open(self):
+        """
+        Open the vending machine.
+        """
+        self._test("open vendy",
+                   ["You open vendy."],
+                   ["Test Player opens vendy."],
+        )
+
+
+    def _close(self):
+        """
+        Close the vending machine.
+        """
+        self._test("close vendy",
+                   ["You close vendy."],
+                   ["Test Player closes vendy."],
+        )
+
+
+    def _create_quiche(self):
+        self._test("create a quiche named quiche",
+                   ["You create a quiche."],
+                   ["Test Player creates a quiche."])
+
+
+    def _put_quiche(self):
+        self._test("put quiche in vendy",
+                   ["You put the quiche in vendy."],
+                   ["Test Player puts a quiche in vendy."])
+
+
+
+    def testTheyExist(self):
+        self._create()
 
 
     def testPopulateVendingMachine(self):
-        self._test("create the 'vending machine' named vendy",
-                   ["You create vendy."],
-                   ["Test Player creates vendy."])
+        self._create()
+        self._open()
+        self._create_quiche()
+        self._put_quiche()
 
-        self._test("create a quiche named quiche",
-                   ["You create a quiche."],
-                   ["Test Player creates a quiche."])
 
-        self._test("open vendy",
-                   ["You open vendy."],
-                   ["Test Player opens vendy."])
+    def testClosedDescription(self):
+        """
+        The contents of a vending machine are not visible when the vending machine
+        is closed.
+        """
+        self._create()
+        self._open()
+        self._create_quiche()
+        self._put_quiche()
+        self._close()
+        self._test(
+            "look at vendy",
+            [commandutils.E("[ vendy ]"),
+             "A vending machine.",
+             "",
+            ],
+            [],
+        )
 
-        self._test("put quiche in vendy",
-                   ["You put the quiche in vendy."],
-                   ["Test Player puts a quiche in vendy."])
+    def closedEmptyDescription(self):
+        """
+        The fact that a vending machine is empty is not visible when the vending
+        machine is closed.
+        """
+        self._create()
+        self._test(
+            "look at vendy",
+            [commandutils.E("[ vendy ]"),
+             "A vending machine.",
+             "",
+            ],
+            [],
+        )
+
+
+    def testOpenDescription(self):
+        """
+        When the vending machine is open its contents are visible.
+        """
+        self._create()
+        self._drop()
+        self._open()
+        self._create_quiche()
+        self._put_quiche()
+        self._test(
+            "look at vendy",
+            [commandutils.E("[ vendy ]"),
+             "A vending machine.",
+             "It contains a quiche.",
+             "",
+            ],
+            [],
+        )
+
+
+    def testOpenEmptyDescription(self):
+        """
+        When the vending machine is open the fact that it is empty is visible.
+        """
+        self._create()
+        self._drop()
+        self._open()
+        self._test(
+            "look at vendy",
+            [commandutils.E("[ vendy ]"),
+             "A vending machine.",
+             "",
+            ],
+            [],
+        )
+
+
+    def _create_quarter(self, name):
+        self._test(
+            "create the quarter named %s" % (name,),
+            ["You create %s." % (name,)],
+            ["Test Player creates %s." % (name,)],
+        )
+
+
+    def _put_quarter(self, name):
+        self._test("put %s in vendy" % (name,),
+                   ["You put %s in vendy." % (name,)],
+                   ["Test Player puts %s in vendy." % (name,)])
 
 
     def testBuyingQuiche(self):
-        self._test("create the 'vending machine' named vendy",
-                   ["You create vendy."],
-                   ["Test Player creates vendy."])
-
-        self._test("drop vendy",
-                   ["You drop vendy."],
-                   ["Test Player drops vendy."])
-
-        self._test("create a quiche named quiche",
-                   ["You create a quiche."],
-                   ["Test Player creates a quiche."])
-
-        self._test("open vendy",
-                   ["You open vendy."],
-                   ["Test Player opens vendy."])
-
-        self._test("put quiche in vendy",
-                   ["You put the quiche in vendy."],
-                   ["Test Player puts a quiche in vendy."])
+        self._create()
+        self._drop()
+        self._create_quiche()
+        self._open()
+        self._put_quiche()
 
         for i in range(5):
-            self._test("create the quarter named quarter%s " % i,
-                       ["You create quarter%s." % i],
-                       ["Test Player creates quarter%s." % i])
+            self._create_quarter("quarter%i" % (i,))
 
         for i in range(4):
-            self._test("put quarter%i in vendy" % i,
-                       ["You put quarter%s in vendy." % i],
-                       ["Test Player puts quarter%s in vendy." % i])
+            self._put_quarter("quarter%i" % (i,))
 
         self._test("put quarter4 in vendy",
                    ["You put quarter4 in vendy.",
@@ -90,4 +197,3 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
         icvm.add(quarter)
 
         self.failUnless(icloc.contains(theQuiche))
-

--- a/ExampleGame/examplegame/test/test_quiche.py
+++ b/ExampleGame/examplegame/test/test_quiche.py
@@ -19,6 +19,9 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
     def _drop(self):
+        """
+        Drop the vending machine.
+        """
         self._test(
             "drop vendy",
             ["You drop vendy."],
@@ -47,12 +50,18 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
     def _create_quiche(self):
+        """
+        Create a quiche.
+        """
         self._test("create a quiche named quiche",
                    ["You create a quiche."],
                    ["Test Player creates a quiche."])
 
 
     def _put_quiche(self):
+        """
+        Put a quiche in the vending machine.
+        """
         self._test("put quiche in vendy",
                    ["You put the quiche in vendy."],
                    ["Test Player puts a quiche in vendy."])
@@ -60,10 +69,16 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
     def testTheyExist(self):
+        """
+        Vending machines can be created because they exist.
+        """
         self._create()
 
 
     def testPopulateVendingMachine(self):
+        """
+        A vending machine can be opened so that an object can be placed in it.
+        """
         self._create()
         self._open()
         self._create_quiche()
@@ -143,6 +158,9 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
     def _create_quarter(self, name):
+        """
+        Create a quarter.
+        """
         self._test(
             "create the quarter named %s" % (name,),
             ["You create %s." % (name,)],
@@ -151,12 +169,19 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
 
 
     def _put_quarter(self, name):
+        """
+        Put a quarter into the vending machine.
+        """
         self._test("put %s in vendy" % (name,),
                    ["You put %s in vendy." % (name,)],
                    ["Test Player puts %s in vendy." % (name,)])
 
 
     def testBuyingQuiche(self):
+        """
+        Putting 5 coins into a vending machine causes it to spit out an object it
+        contains.
+        """
         self._create()
         self._drop()
         self._create_quiche()

--- a/ExampleGame/examplegame/test/test_quiche.py
+++ b/ExampleGame/examplegame/test/test_quiche.py
@@ -104,7 +104,7 @@ class VendingTest(commandutils.CommandTestCaseMixin, unittest.TestCase):
             [],
         )
 
-    def closedEmptyDescription(self):
+    def testClosedEmptyDescription(self):
         """
         The fact that a vending machine is empty is not visible when the vending
         machine is closed.


### PR DESCRIPTION
Fixes #98 

This also deletes some dead code, refactors the test suite, and fixes another bug related to trying to buy something when the vending machine is empty (tested by new method `testEmptyVendingMachinePurchase`).